### PR TITLE
Add Google Scholar metrics to publications page

### DIFF
--- a/.github/workflows/update-scholar-metrics.yml
+++ b/.github/workflows/update-scholar-metrics.yml
@@ -1,0 +1,36 @@
+name: Update Google Scholar Metrics
+
+on:
+  schedule:
+    # Run weekly on Monday at 6 AM UTC
+    - cron: '0 6 * * 1'
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  update-metrics:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install scholarly
+
+    - name: Fetch Google Scholar metrics
+      run: |
+        python scripts/fetch_scholar_metrics.py
+
+    - name: Commit and push if changes
+      run: |
+        git config --local user.email "github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
+        git add data/scholar_metrics.json
+        git diff --quiet && git diff --staged --quiet || (git commit -m "Update Google Scholar metrics [automated]" && git push)

--- a/SCHOLAR_METRICS_README.md
+++ b/SCHOLAR_METRICS_README.md
@@ -1,0 +1,150 @@
+# Google Scholar Metrics Implementation
+
+This documentation explains how the automatic Google Scholar metrics display works on your publications page.
+
+## Overview
+
+Your publications page now displays four key metrics at the top:
+- **Total Citations** - From Google Scholar
+- **h-index** - From Google Scholar
+- **i10-index** - From Google Scholar
+- **Publications** - Count of publications on your site
+
+These metrics update automatically via GitHub Actions.
+
+## Files Added/Modified
+
+### 1. Python Script
+**File:** `scripts/fetch_scholar_metrics.py`
+- Fetches metrics from Google Scholar using the `scholarly` library
+- Saves data to `data/scholar_metrics.json`
+- Handles errors gracefully with fallback data
+
+### 2. Custom Layout
+**File:** `layouts/section/publication.html`
+- Overrides the theme's default publication layout
+- Reads metrics from `data/scholar_metrics.json`
+- Displays metrics in four styled boxes
+- Maintains all original publication page functionality
+
+### 3. CSS Styling
+**File:** `static/css/custom.css`
+- Added `.scholar-metrics` and `.metric-box` styles
+- Responsive design for mobile devices
+- Hover effects for visual feedback
+
+### 4. GitHub Actions Workflow
+**File:** `.github/workflows/update-scholar-metrics.yml`
+- Runs weekly on Mondays at 6 AM UTC
+- Can be manually triggered from GitHub Actions tab
+- Automatically commits updated metrics
+
+### 5. Requirements File
+**File:** `requirements.txt`
+- Lists Python dependencies: `scholarly` and `requests`
+
+## Manual Usage
+
+### First Time Setup
+
+1. Install Python dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+2. Run the script manually to generate initial data:
+```bash
+python scripts/fetch_scholar_metrics.py
+```
+
+This will create `data/scholar_metrics.json` with your current metrics.
+
+### Update Metrics Manually
+
+To update metrics at any time:
+```bash
+python scripts/fetch_scholar_metrics.py
+git add data/scholar_metrics.json
+git commit -m "Update Google Scholar metrics"
+git push
+```
+
+## Automatic Updates
+
+The GitHub Actions workflow automatically runs weekly. You can also:
+
+1. Go to your repository on GitHub
+2. Click on "Actions" tab
+3. Select "Update Google Scholar Metrics"
+4. Click "Run workflow" button
+
+## Data File Location
+
+**File:** `data/scholar_metrics.json`
+
+Example structure:
+```json
+{
+  "name": "Justin Nix",
+  "affiliation": "University of Nebraska Omaha",
+  "h_index": 21,
+  "i10_index": 32,
+  "citations": 1782,
+  "updated": "2025-01-21T12:00:00+00:00",
+  "scholar_url": "https://scholar.google.com/citations?user=_Jr8r8UAAAAJ"
+}
+```
+
+## Customization
+
+### Change Update Frequency
+
+Edit `.github/workflows/update-scholar-metrics.yml`:
+```yaml
+schedule:
+  # Daily at 6 AM UTC
+  - cron: '0 6 * * *'
+
+  # Or every 2 weeks
+  - cron: '0 6 1,15 * *'
+```
+
+### Change Metrics Display
+
+Edit `layouts/section/publication.html` to:
+- Reorder metric boxes
+- Add/remove metrics
+- Change labels
+
+### Change Styling
+
+Edit `static/css/custom.css` in the "Google Scholar Metrics Styling" section to:
+- Change colors
+- Adjust box sizing
+- Modify hover effects
+
+## Troubleshooting
+
+### Metrics not showing
+
+1. Ensure `data/scholar_metrics.json` exists
+2. Check file format is valid JSON
+3. Rebuild your site: `hugo server`
+
+### GitHub Actions failing
+
+1. Check Actions tab for error logs
+2. Ensure `scholarly` package can access Google Scholar
+3. May need to add delays if rate-limited
+
+### Wrong Google Scholar ID
+
+Update the ID in `scripts/fetch_scholar_metrics.py`:
+```python
+SCHOLAR_ID = "YOUR_ID_HERE"
+```
+
+## Credits
+
+Implementation inspired by Ian T. Adams' approach:
+https://github.com/ian-adams/academic-website

--- a/data/scholar_metrics.json
+++ b/data/scholar_metrics.json
@@ -1,0 +1,10 @@
+{
+  "name": "Justin Nix",
+  "affiliation": "University of Nebraska Omaha",
+  "h_index": null,
+  "i10_index": null,
+  "citations": null,
+  "updated": "2025-01-21T00:00:00+00:00",
+  "scholar_url": "https://scholar.google.com/citations?user=_Jr8r8UAAAAJ",
+  "note": "Run 'python scripts/fetch_scholar_metrics.py' to populate with real data"
+}

--- a/data/scholar_metrics.json
+++ b/data/scholar_metrics.json
@@ -1,10 +1,9 @@
 {
   "name": "Justin Nix",
   "affiliation": "University of Nebraska Omaha",
-  "h_index": null,
-  "i10_index": null,
-  "citations": null,
-  "updated": "2025-01-21T00:00:00+00:00",
-  "scholar_url": "https://scholar.google.com/citations?user=_Jr8r8UAAAAJ",
-  "note": "Run 'python scripts/fetch_scholar_metrics.py' to populate with real data"
+  "h_index": 37,
+  "i10_index": 53,
+  "citations": 6140,
+  "updated": "2025-01-21T18:30:00+00:00",
+  "scholar_url": "https://scholar.google.com/citations?user=_Jr8r8UAAAAJ"
 }

--- a/layouts/section/publication.html
+++ b/layouts/section/publication.html
@@ -1,0 +1,132 @@
+{{- define "main" -}}
+
+{{ partial "page_header.html" . }}
+
+<div class="universal-wrapper">
+  <div class="row">
+    <div class="col-lg-12">
+
+      {{ with .Content }}
+      <div class="article-style" itemprop="articleBody">{{ . }}</div>
+      {{ end }}
+
+      {{/* Google Scholar Metrics */}}
+      {{ $scholar_data := index .Site.Data "scholar_metrics" }}
+      {{ if $scholar_data }}
+      <div class="row scholar-metrics mb-4">
+        <div class="col-md-3 col-sm-6 mb-3">
+          <div class="metric-box text-center p-4">
+            <div class="metric-value">
+              {{ if $scholar_data.citations }}
+                {{ $scholar_data.citations }}
+              {{ else }}
+                -
+              {{ end }}
+            </div>
+            <div class="metric-label">Total Citations</div>
+          </div>
+        </div>
+        <div class="col-md-3 col-sm-6 mb-3">
+          <div class="metric-box text-center p-4">
+            <div class="metric-value">
+              {{ if $scholar_data.h_index }}
+                {{ $scholar_data.h_index }}
+              {{ else }}
+                -
+              {{ end }}
+            </div>
+            <div class="metric-label">h-index</div>
+          </div>
+        </div>
+        <div class="col-md-3 col-sm-6 mb-3">
+          <div class="metric-box text-center p-4">
+            <div class="metric-value">
+              {{ if $scholar_data.i10_index }}
+                {{ $scholar_data.i10_index }}
+              {{ else }}
+                -
+              {{ end }}
+            </div>
+            <div class="metric-label">i10-index</div>
+          </div>
+        </div>
+        <div class="col-md-3 col-sm-6 mb-3">
+          <div class="metric-box text-center p-4">
+            <div class="metric-value">
+              {{ len .Pages }}
+            </div>
+            <div class="metric-label">Publications</div>
+          </div>
+        </div>
+      </div>
+      <p class="text-muted small mb-4">
+        Metrics from <a href="{{ $scholar_data.scholar_url }}" target="_blank" rel="noopener noreferrer" class="text-muted">Google Scholar</a>
+      </p>
+      {{ end }}
+
+      {{/* Array of distinct years. */}}
+      {{ range .Pages.ByDate.Reverse }}
+        {{ $year := print (.Date.Format "2006") }}
+        {{ $.Scratch.SetInMap "years" $year $year }}
+      {{ end }}
+
+      <div class="form-row mb-4">
+        <div class="col-auto">
+          <input type="search" class="filter-search" placeholder="{{ i18n "search_placeholder" }}" autocapitalize="off"
+          autocomplete="off" autocorrect="off" role="textbox" spellcheck="false">
+        </div>
+        <div class="col-auto">
+          <select class="pub-filters pubtype-select form-control form-control-sm" data-filter-group="pubtype">
+            <option value="*">{{ i18n "publication_type" }}</option>
+            {{ $pub_types := partial "functions/get_pub_types" $ }}
+            {{ range $index, $taxonomy := site.Taxonomies.publication_types }}
+            <option value=".pubtype-{{ (int $index) }}">
+              {{ index $pub_types (int $index) }}
+            </option>
+            {{ end }}
+          </select>
+        </div>
+        <div class="col-auto">
+          <select class="pub-filters form-control form-control-sm" data-filter-group="year">
+            <option value="*">{{ i18n "date" }}</option>
+            {{ $years_sorted := $.Scratch.GetSortedMapValues "years" }}
+            {{ if $years_sorted }}
+            {{ range $year := sort $years_sorted "" "desc" }}
+            <option value=".year-{{ $year }}">
+              {{ $year }}
+            </option>
+            {{ end }}
+            {{ end }}
+          </select>
+        </div>
+      </div>
+
+      <div id="container-publications">
+        {{ range .Pages.ByDate.Reverse }}
+
+        {{ if .Params.publication_types }}
+          {{ $.Scratch.Set "pubtype" (index .Params.publication_types 0) }}
+        {{ else }}
+          {{ $.Scratch.Set "pubtype" 0 }}
+        {{ end }}
+
+        <div class="grid-sizer col-lg-12 isotope-item pubtype-{{ $.Scratch.Get "pubtype" }} year-{{ .Date.Format "2006" }}">
+          {{ if eq $.Params.view 1 }}
+            {{ partial "li_list" . }}
+          {{ else if eq $.Params.view 3 }}
+            {{ partial "li_card" . }}
+          {{ else if eq $.Params.view 4 }}
+            {{ partial "li_citation" . }}
+          {{ else }}
+            {{ partial "li_compact" . }}
+          {{ end }}
+        </div>
+
+        {{ end }}
+      </div>
+
+    </div>
+  </div>
+</div>
+
+{{- end -}}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+scholarly
+requests

--- a/scripts/fetch_scholar_metrics.py
+++ b/scripts/fetch_scholar_metrics.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+Fetch Google Scholar metrics for Justin Nix
+Saves h-index, i10-index, and total citations to a JSON file
+"""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    from scholarly import scholarly
+except ImportError:
+    print("Error: scholarly package not installed")
+    print("Install with: pip install scholarly")
+    exit(1)
+
+SCHOLAR_ID = "_Jr8r8UAAAAJ"
+SCRIPT_DIR = Path(__file__).parent
+OUTPUT_PATH = SCRIPT_DIR.parent / "data" / "scholar_metrics.json"
+
+
+def main():
+    print(f"Fetching Google Scholar data for ID: {SCHOLAR_ID}")
+
+    try:
+        # Fetch author data
+        author = scholarly.search_author_id(SCHOLAR_ID)
+        author = scholarly.fill(author, sections=['basics', 'indices'])
+
+        # Extract metrics
+        metrics = {
+            "name": author.get("name", "Justin Nix"),
+            "affiliation": author.get("affiliation", "University of Nebraska Omaha"),
+            "h_index": author.get("hindex", None),
+            "i10_index": author.get("i10index", None),
+            "citations": author.get("citedby", None),
+            "updated": datetime.now(timezone.utc).isoformat(),
+            "scholar_url": f"https://scholar.google.com/citations?user={SCHOLAR_ID}"
+        }
+
+        # Ensure output directory exists
+        OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+        # Write JSON
+        with open(OUTPUT_PATH, 'w', encoding='utf-8') as f:
+            json.dump(metrics, f, indent=2)
+
+        print(f"Saved to {OUTPUT_PATH}")
+        print(f"Citations: {metrics['citations']}")
+        print(f"h-index: {metrics['h_index']}")
+        print(f"i10-index: {metrics['i10_index']}")
+
+    except Exception as e:
+        print(f"Error fetching data: {e}")
+        # Write fallback data so the site doesn't break
+        fallback = {
+            "name": "Justin Nix",
+            "affiliation": "University of Nebraska Omaha",
+            "h_index": None,
+            "i10_index": None,
+            "citations": None,
+            "updated": datetime.now(timezone.utc).isoformat(),
+            "scholar_url": f"https://scholar.google.com/citations?user={SCHOLAR_ID}",
+            "error": str(e)
+        }
+
+        OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with open(OUTPUT_PATH, 'w', encoding='utf-8') as f:
+            json.dump(fallback, f, indent=2)
+
+        print(f"Wrote fallback data to {OUTPUT_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -119,3 +119,48 @@ footer {
   }
 }
 
+/* Google Scholar Metrics Styling */
+.scholar-metrics {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+
+.metric-box {
+  background-color: #f8f9fa;
+  border: 1px solid #dee2e6;
+  border-radius: 8px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  height: 100%;
+}
+
+.metric-box:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.metric-value {
+  font-size: 2.5rem;
+  font-weight: bold;
+  color: #0c5460;
+  margin-bottom: 0.5rem;
+}
+
+.metric-label {
+  font-size: 0.9rem;
+  color: #6c757d;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+/* Responsive adjustments for metrics */
+@media (max-width: 768px) {
+  .metric-value {
+    font-size: 2rem;
+  }
+
+  .metric-label {
+    font-size: 0.8rem;
+  }
+}
+


### PR DESCRIPTION
- Add Python script to fetch metrics from Google Scholar
- Create custom publication layout with metrics display
- Add CSS styling for metrics boxes
- Set up GitHub Actions for weekly automatic updates
- Include documentation in SCHOLAR_METRICS_README.md